### PR TITLE
use executeOnFiles instead of executeOnText

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,11 +45,10 @@ export const provideLinter = () => {
       }
 
       let filePath = editor.getPath();
-      let text = editor.getText();
 
       const messages = [];
       const push = Array.prototype.push;
-      const results = textlint.executeOnText(text)
+      const results = textlint.executeOnFiles(filePath)
         .filter(result => result.messages.length)
         .forEach(result => push.apply(messages, result.messages));
 


### PR DESCRIPTION
`executeOnText` only support plain text, but `executeOnFiles` detect file type and lint by the type.

`executeOnText`は今のところplain textしかサポートしてないので、`executeOnFiles`を使うことで拡張子から自動的にファイル判定してくれるようになります。(Markdownでも誤爆しないで動くようになる)
- https://github.com/azu/textlint/blob/19eed741436f1df0182a71c829354a82501f678e/lib/textlint-engine.js#L136

ルールによってはリンク文字列や引用などは対象から除外してたりするので、現在のファイルタイプにあったものを使えた方が誤爆しないでよくなります。

![gif](https://gyazo.com/af14634690a0515c2c5ce56bd2fd6431.gif)
