### PR TITLE
Update textlint to 4.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,8 +29,10 @@ export const activate = () => {
   }
 
   // initialize textlint
-  textlint = new TextLintEngine({ configFile: configFile });
-  textlint.setRulesBaseDirectory(pluginPath);
+  textlint = new TextLintEngine({
+    configFile: configFile,
+    rulesBaseDirectory: pluginPath
+  });
 };
 
 export const provideLinter = () => {
@@ -54,14 +56,15 @@ export const provideLinter = () => {
         .forEach(result => push.apply(messages, result.messages));
 
       return messages.map(message => {
-
+        // line and column 1-based index
+        // https://github.com/azu/textlint/blob/master/docs/use-as-modules.md
         let range = new Range(
-          [message.loc.start.line - 1, message.loc.start.column],
-          [message.loc.end.line - 1, message.loc.end.column]
+          [message.line - 1, message.column - 1],
+          [message.line - 1, message.column - 1]
         );
 
         return {
-          type: message.type,
+          type: textlint.isErrorMessage(message) ? "Error" : "Warning",
           text: message.message,
           filePath: filePath,
           range: range

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "atom-linter": "^3.2.2",
     "atom-package-deps": "^2.1.3",
-    "textlint": "^3.7.1"
+    "textlint": "^4.0.0"
   },
   "package-deps": [
     "linter"


### PR DESCRIPTION
[textlint 4.0.0](https://github.com/azu/textlint/releases/tag/4.0.0) has a breaking change about column number.
https://github.com/azu/textlint/issues/42

This pull request fixes the breaking change issue and correct Messages `type`
- https://github.com/atom-community/linter/wiki/Linter-API#messages

![2015-10-17_15-22-37](https://cloud.githubusercontent.com/assets/19714/10557349/97488056-74e3-11e5-9ccf-6c2ad9a0e2a0.jpg)

FYI: `TextLintEngine#executeOnText` support `ext` 2nd arguments in 4.0.0.
