### PR TITLE
feature: use of global .textlintrc 

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,10 +10,31 @@ $ apm install linter-textlint
 
 ## Configuration
 
+### Use your project `.textlintrc` and the rule
+
 You have to do following steps before using.
 
-1. Put `.textlintrc` in your workspace ( [`.textlintrc` file format](https://github.com/azu/textlint#textlintrc) ).
-2. Install textlint plugins (`textlint-rule-*`) in your workspace.
+1. Put `.textlintrc` in your workspace ( [`.textlintrc` file format](https://github.com/textlint/textlint#textlintrc) ).
+2. Install textlint plugins (`textlint-rule-*`) in your workspace via `npm install`.
+3. Open the workspace with Atom Editor.
+
+### Use global `.textlintrc` and the rule
+
+You have to do following steps before using.
+
+1. Put `.textlintrc` in any directory ( [`.textlintrc` file format](https://github.com/textlint/textlint#textlintrc) ).
+2. Install textlint plugins (`textlint-rule-*`) in any directory via `npm install`.
+3. Open Atom and Show linter-textlint's setting.
+4. Set following setting:
+
+- **.textlintrc Path** : path to `.textlintrc`. It will only be used when there's no config file in project
+    - e.g.) `/Users/work/my-textlint-config/.textlintrc`
+- **textlint Rules Dir**: path to node_modules directory. It will only be used when there's no config file in project
+    - e.g.) `/Users/work/my-textlint-config/node_modules`
+
+![setting](https://monosnap.com/file/R6reaywGTmZMkgob15BEdyhHDvaeQF.png)
+
+Open any file(The workspace has not config file) with Atom Editor.
 
 ## License
 


### PR DESCRIPTION
This pull request add new feature that allow to use global(any) `.textlintrc` config.

Add two config to the linter-textlint.
- **.textlintrc Path** : path to `.textlintrc`. It will only be used when there's no config file in project
  - e.g.) `/Users/work/my-textlint-config/.textlintrc`
- **textlint Rules Dir**: path to node_modules directory. It will only be used when there's no config file in project
  - e.g.) `/Users/work/my-textlint-config/node_modules`

Screenshot:

![setting](https://monosnap.com/file/R6reaywGTmZMkgob15BEdyhHDvaeQF.png)

![example - atom 2015-12-04 10-14-31](https://cloud.githubusercontent.com/assets/19714/11579839/e7b13ebe-9a74-11e5-919e-5a55627e026d.png)

It is very inspired by [AtomLinter/linter-eslint](https://github.com/AtomLinter/linter-eslint)
