### PR TITLE
Support language-markdown

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -49,7 +49,7 @@ function existsConfig(configFile, pluginPath) {
 export function provideLinter() {
   return {
     name: 'textlint',
-    grammarScopes: ['source.gfm', 'source.pfm', 'source.txt'],
+    grammarScopes: ['source.gfm', 'source.pfm', 'source.txt', 'text.md'],
     scope: 'file',
     lintOnFly: true,
     lint: editor => {


### PR DESCRIPTION
### Summary

Added `text.md` to grammerScopes.
### Motivation

The linter-textlint doesn't work with [language-markdown](https://atom.io/packages/language-markdown) because it treats markdown file as `text.md`. The language-markdown package is pretty popular, so supporting it makes sense.
