### PR TITLE
Improve the readability of error ranges

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,8 +1,8 @@
 'use babel';
 
 import * as fs from 'fs';
-import { Range } from 'atom';
 import { TextLintEngine } from 'textlint';
+import { rangeFromLineNumber } from 'atom-linter';
 
 // User config
 export const config = {
@@ -91,12 +91,17 @@ export function provideLinter() {
           .forEach(result => push.apply(messages, result.messages));
 
         return messages.map(message => {
-          // line and column 1-based index
+          // line and column are 1-based index
           // https://github.com/azu/textlint/blob/master/docs/use-as-modules.md
-          const range = new Range(
-            [message.line - 1, message.column - 1],
-            [message.line - 1, message.column - 1]
-          );
+          const { line, column } = message;
+          const range = rangeFromLineNumber(editor, line - 1);
+
+          if (column) {
+            range[0][1] = column - 1;
+          }
+          if (column > range[1][1]) {
+            range[1][1] = column - 1;
+          }
 
           return {
             type: textlint.isErrorMessage(message) ? 'Error' : 'Warning',

--- a/spec/linter-textlint-spec.js
+++ b/spec/linter-textlint-spec.js
@@ -38,10 +38,10 @@ describe('The textlint provider for Linter', () => {
           expect(messages[0].type).toEqual('Error');
           expect(messages[0].text).toEqual('Java Script => JavaScript');
           expect(messages[0].filePath).toMatch(/.+bad\.md$/);
-          expect(messages[0].range).toEqual({
-            start: { row: 2, column: 4 },
-            end: { row: 2, column: 4 }
-          });
+          expect(messages[0].range).toEqual([
+            [2, 4],
+            [2, 16]
+          ]);
         })
       );
     });


### PR DESCRIPTION
Hi!

Currently the `linter-textlint` provides 0-sized ranges for error/warning reports,
which makes it a little bit hard to see which part of sentence actually causes an error/warning.

This PR introduces an range decision algorithm that is adopted on `linter-eslint`, https://github.com/AtomLinter/linter-eslint/blob/master/src/main.js#L154-L160

Sometimes it becomes annoying when too many and long red underlines are appeared, but Textlint (and also ESLint too) only inform `line` and `column` of the start of a range in terms of a positon of an error/warning, so the end of a underlined section becomes always at the end of a line.

I believe this change improves the detectability of error/warning positions.
## Before

![write-good](https://cloud.githubusercontent.com/assets/27622/13904319/fda55682-eedf-11e5-89aa-f5b51c15c7b5.png)
## After

![write-good-after](https://cloud.githubusercontent.com/assets/27622/13904322/065511fa-eee0-11e5-99a0-23a57aa8c235.png)
