### PR TITLE
Add 'Show Rule ID in Messages' option

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@
 import * as fs from 'fs';
 import { TextLintEngine } from 'textlint';
 import { rangeFromLineNumber } from 'atom-linter';
+import escapeHTML from 'escape-html';
 
 // User config
 export const config = {
@@ -19,14 +20,21 @@ It will only be used when there's no config file in project.
 Write the value of path to node_modules.`,
     type: 'string',
     default: ''
+  },
+  showRuleIdInMessage: {
+    title: 'Show Rule ID in Messages',
+    type: 'boolean',
+    default: true
   }
 };
 
 const TEXTLINT_RC_PATH = 'linter-textlint.textlintrcPath';
 const TEXTLINT_RULES_DIR = 'linter-textlint.textlintRulesDir';
+const SHOW_RULE_ID_IN_MESSAGE = 'linter-textlint.showRuleIdInMessage';
 
 let textlintrcPath;
 let textlintRulesDir;
+let showRuleId;
 
 export function activate() {
   // install deps
@@ -34,12 +42,16 @@ export function activate() {
 
   textlintrcPath = atom.config.get(TEXTLINT_RC_PATH);
   textlintRulesDir = atom.config.get(TEXTLINT_RULES_DIR);
+  showRuleId = atom.config.get(SHOW_RULE_ID_IN_MESSAGE);
 
   atom.config.observe(TEXTLINT_RC_PATH, value => {
     textlintrcPath = value;
   });
   atom.config.observe(TEXTLINT_RULES_DIR, value => {
     textlintRulesDir = value;
+  });
+  atom.config.observe(SHOW_RULE_ID_IN_MESSAGE, value => {
+    showRuleId = value;
   });
 }
 
@@ -103,12 +115,22 @@ export function provideLinter() {
             range[1][1] = column - 1;
           }
 
-          return {
+          const linterMessage = {
             type: textlint.isErrorMessage(message) ? 'Error' : 'Warning',
-            text: message.message,
             filePath,
             range
           };
+
+          if (showRuleId) {
+            const ruleId = message.ruleId;
+            const badge = `<span class="badge badge-flexible textlint">${ruleId}</span>`;
+            const escapedMessage = escapeHTML(message.message);
+            linterMessage.html = `${badge} ${escapedMessage}`;
+          } else {
+            linterMessage.text = message.message;
+          }
+
+          return linterMessage;
         });
       });
     }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "atom-linter": "^4.6.1",
     "atom-package-deps": "^4.0.1",
+    "escape-html": "^1.0.3",
     "textlint": "^6.0.1"
   },
   "devDependencies": {

--- a/spec/linter-textlint-spec.js
+++ b/spec/linter-textlint-spec.js
@@ -14,6 +14,7 @@ describe('The textlint provider for Linter', () => {
     atom.workspace.destroyActivePaneItem();
     atom.config.set('linter-textlint.textlintrcPath', textlintrcPath);
     atom.config.set('linter-textlint.textlintRulesDir', textlintRulesDir);
+    atom.config.set('linter-textlint.showRuleIdInMessage', false);
 
     waitsForPromise(() =>
       Promise.all([
@@ -37,11 +38,24 @@ describe('The textlint provider for Linter', () => {
         atom.workspace.open(bad).then(editor => lint(editor)).then(messages => {
           expect(messages[0].type).toEqual('Error');
           expect(messages[0].text).toEqual('Java Script => JavaScript');
+          expect(messages[0].html).not.toBeDefined();
           expect(messages[0].filePath).toMatch(/.+bad\.md$/);
           expect(messages[0].range).toEqual([
             [2, 4],
             [2, 16]
           ]);
+        })
+      );
+    });
+
+    it('verifies the first message contains a rule ID', () => {
+      atom.config.set('linter-textlint.showRuleIdInMessage', true);
+
+      waitsForPromise(() =>
+        atom.workspace.open(bad).then(editor => lint(editor)).then(messages => {
+          expect(messages[0].text).not.toBeDefined();
+          // eslint-disable-next-line max-len
+          expect(messages[0].html).toEqual('<span class="badge badge-flexible textlint">spellcheck-tech-word</span> Java Script =&gt; JavaScript');
         })
       );
     });


### PR DESCRIPTION
Hi!

This PR introduces another feature from `linter-eslint`, the 'Show Rule ID in Messages' option.
It is useful especially when multiple rules are enabled.
The default value of this option is set to be `true`(enabled), which is the same as that of `linter-eslint`.

I'm not sure this PR conflicts the previous one, so if it does, I'll fix.
## Before

![write-good](https://cloud.githubusercontent.com/assets/27622/13904612/4282f19c-eeea-11e5-81d0-5222c01925e7.png)
## After

![write-good-show-rule-id](https://cloud.githubusercontent.com/assets/27622/13904630/941628a8-eeea-11e5-83d8-11981e1b8a3a.png)
