### PR TITLE
Fix plain text support was not working

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -53,7 +53,7 @@ function existsConfig(configFile, pluginPath) {
 export function provideLinter() {
   return {
     name: 'textlint',
-    grammarScopes: ['source.gfm', 'source.pfm', 'source.txt', 'text.md'],
+    grammarScopes: ['source.gfm', 'source.pfm', 'text.plain', 'text.md'],
     scope: 'file',
     lintOnFly: true,
     lint: editor => {


### PR DESCRIPTION
Hi,

I've found that linter-textlint does not check plain text files (i.e. `*.txt`) at all.

This is because the scope name for plain text is `text.plain`, and linter-textlint uses `source.txt` which is wrong I think.

This PR is just a tiny fix for supporting plain text files properly.
