### PR TITLE
Add source.review grammar scope

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -41,6 +41,7 @@ export function provideLinter() {
       'source.gfm',
       'source.pfm',
       'source.re',
+      'source.review',
       'text.plain',
       'text.md'
     ],


### PR DESCRIPTION
Related to https://github.com/1000ch/linter-textlint/issues/42

Re:VIEW file doesn't have official grammar scope.
When we use `vvakame/language-review`, grammar scope of Re:VIEW file is set to `source.review`